### PR TITLE
adding a call to `make build` on babel before packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <upstream.version>4.7.16</upstream.version>
-        <upstream.url>https://github.com/babel/babel/archive/v${upstream.version}.zip</upstream.url>
+
+        <upstream.url>https://registry.npmjs.org/babel-core/-/babel-core-${upstream.version}.tgz</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
-        <jsBuildDir>${project.build.directory}/${project.artifactId}-${upstream.version}</jsBuildDir>
+        <extractDir>${project.build.directory}/${project.artifactId}-${upstream.version}</extractDir>
         <requirejs>
             {
             }
@@ -65,25 +66,16 @@
                             <target>
 
                                 <echo message="download archive" />
+                                <get src="${upstream.url}" dest="${project.build.directory}/${project.artifactId}.tgz" />
 
-                                <get src="${upstream.url}" dest="${project.build.directory}/${project.artifactId}.zip" />
-
-                                <echo message="unzip archive" />
-                                <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
-
-                                <echo message="bootstrapping js project" />
-                                <exec executable="npm" failonerror="true" dir="${jsBuildDir}">
-                                    <arg value="install" />
-                                </exec>
-
-                                <echo message="building js project" />
-                                <exec executable="make" failonerror="true" dir="${jsBuildDir}">
-                                    <arg value="build" />
-                                </exec>
+                                <echo message="uncompress archive" />
+                                <gunzip src="${project.build.directory}/${project.artifactId}.tgz" dest="${project.build.directory}/${project.artifactId}.tar" />
+                                <untar src="${project.build.directory}/${project.artifactId}.tar" dest="${extractDir}" />
 
                                 <echo message="moving resources" />
+
                                 <move todir="${destDir}">
-                                    <fileset dir="${jsBuildDir}/dist" />
+                                    <fileset dir="${extractDir}/package" />
                                 </move>
 
                             </target>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <upstream.version>4.7.16</upstream.version>
         <upstream.url>https://github.com/babel/babel/archive/v${upstream.version}.zip</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
+        <jsBuildDir>${project.build.directory}/${project.artifactId}-${upstream.version}</jsBuildDir>
         <requirejs>
             {
             }
@@ -62,14 +63,29 @@
                         <goals><goal>run</goal></goals>
                         <configuration>
                             <target>
+
                                 <echo message="download archive" />
+
                                 <get src="${upstream.url}" dest="${project.build.directory}/${project.artifactId}.zip" />
+
                                 <echo message="unzip archive" />
                                 <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
+
+                                <echo message="bootstrapping js project" />
+                                <exec executable="npm" failonerror="true" dir="${jsBuildDir}">
+                                    <arg value="install" />
+                                </exec>
+
+                                <echo message="building js project" />
+                                <exec executable="make" failonerror="true" dir="${jsBuildDir}">
+                                    <arg value="build" />
+                                </exec>
+
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/${project.artifactId}-${upstream.version}" />
+                                    <fileset dir="${jsBuildDir}/dist" />
                                 </move>
+
                             </target>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,19 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>babel</artifactId>
-    <version>4.7.17-SNAPSHOT</version>
+    <version>4.7.16-1-SNAPSHOT</version>
     <name>Babel</name>
     <description>WebJar for Babel</description>
     <url>http://webjars.org</url>
+
+
+    <dependencies>
+        <!--<dependency>-->
+            <!--<groupId>org.webjars</groupId>-->
+            <!--<artifactId>lodash</artifactId>-->
+            <!--<version>3.3.1</version>-->
+        <!--</dependency>-->
+    </dependencies>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -71,6 +80,10 @@
                                 <echo message="uncompress archive" />
                                 <gunzip src="${project.build.directory}/${project.artifactId}.tgz" dest="${project.build.directory}/${project.artifactId}.tar" />
                                 <untar src="${project.build.directory}/${project.artifactId}.tar" dest="${extractDir}" />
+
+                                <exec executable="npm" failonerror="true" dir="${extractDir}/package">
+                                    <arg value="install" />
+                                </exec>
 
                                 <echo message="moving resources" />
 


### PR DESCRIPTION
The existing webjar doesn't seem to expose the package to jsengine as expected. Still getting `Error: Cannot find module` during plugin execution.

Added some extra steps to run make build on the node project (unsure if this is the preferred way to go about it). Still, when I add my patched version as a dep on my plugin, it's still failing to expose the package, so I'm not sure this is even the problem.

![](http://i.imgur.com/X1Xj03S.jpg)

Any ideas?
